### PR TITLE
Fix "Getting started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Docker image exposes simple APIs to render formulas using MathJax on the se
 To get started, simply run a container from this image:
 
 ```
-$ docker run --name mathjax-node -d -p 8080:80 chialab/mathjax-node
+$ docker run --name mathjax-docker -d -p 8080:80 chialab/mathjax-docker
 ```
 
 This will expose the API on port `8080`.


### PR DESCRIPTION
It seems like the repository name changed at some point, but the "Getting started" section wasn't updated. Running the command results in:

```
$ docker run --name mathjax-node -d -p 8080:80 chialab/mathjax-node
Unable to find image 'chialab/mathjax-node:latest' locally
docker: Error response from daemon: pull access denied for chialab/mathjax-node, repository does not exist or may require 'docker login'.
```

The proposed change fixes that.